### PR TITLE
Redirect 404 to /index.html

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,5 +36,6 @@ module.exports = {
   devServer: {
     inline: true,
     hot: true,
+    historyApiFallback: true,
   },
 }


### PR DESCRIPTION
You need to set historyApiFallback to true. Remember http://localhost:8080/me is in fact not exist on server so this will result in 404. By setting this option to true webpack-dev-server will return index.html instead of 404. In case you use html-webpack-plugin to generate index.html in your publicPath, you need to set historyFallbackApi like so:

devServer: {
  historyFallbackApi: {
    index: publicPath
  }
}

in order that webpack-dev-server will search for index.html in your publicPath.

In case you use express server instead of webpack-dev-server you can use below code to simulate same effect

import express from 'express'
const app = express()
app.use(express.static(publicPath))
app.get('*', (response, callback) => {
  response.sendFile(path.resolve(__dirname, publicPath, 'index.html'))
})
app.listen(8080)
